### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/test_singles.py
+++ b/test_singles.py
@@ -97,7 +97,7 @@ def plots(x, e0, ecal, dt, efit_label):
         kde=False,
         fit=stats.norm,
         axlabel="time (ps)",
-        label="Normal fit $\mu=${:.1f}, $\sigma=${:.2f}".format(*stats.norm.fit(dt)),
+        label=r"Normal fit $\mu=${:.1f}, $\sigma=${:.2f}".format(*stats.norm.fit(dt)),
         ax=ax[2],
     )
     a.legend()
@@ -114,10 +114,10 @@ def plots(x, e0, ecal, dt, efit_label):
         y="energy (keV)",
         xlim=[0, 300],
         ylim=[0, 1500],
-        joint_kws=dict(gridsize=50),
+        joint_kws={"gridsize": 50},
         ratio=2,
         kind="hex",
-        marginal_kws=dict(bins=500),
+        marginal_kws={"bins": 500},
     )
     a.ax_joint.text(10, 1400, efit_label)
     plt.savefig("energy_calibration.png", dpi=200)


### PR DESCRIPTION
## Summary

- apply Ruff 0.16.0 string and mapping literal fixes
- preserve plotting behavior and Python 3.8 compatibility

## Validation

- pinned Ruff 0.16.0 shared Actions check and format commands
- Python 3.8 compileall

Deleted: redundant `dict()` constructor calls.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves plotting code readability and ensures the normal-fit label renders correctly in `test_singles.py`. 🛠️

### 📊 Key Changes
- Added a raw string prefix to the Matplotlib label containing LaTeX-style symbols.
- Replaced `dict(...)` calls with standard dictionary literals for plotting options.
- No changes to calculations, data processing, or output behavior beyond label rendering.

### 🎯 Purpose & Impact
- Prevents unintended escape-sequence handling in the `μ` and `σ` plot label. 📈
- Makes the plotting configuration more consistent and easier to maintain.
- Keeps generated calibration plots functionally unchanged while improving code quality. ✅