### PR TITLE
Align README tail sections with Ultralytics standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ If you find this dataset or our analysis tools beneficial for your research, ple
 
 [![DOI](https://zenodo.org/badge/133869433.svg)](https://zenodo.org/badge/latestdoi/133869433)
 
-## 🤝 Contribute
+## 💡 Contribute
 
 Contributions from the community are highly encouraged! Whether it's fixing bugs, proposing new features, or enhancing documentation, your input helps us improve. Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing) for details on how to get started. We'd also appreciate hearing about your experience using Ultralytics products through our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A heartfelt 🙏 thank you to all our contributors!
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-## ©️ License
+## 📄 License
 
 Ultralytics provides two licensing options to accommodate diverse needs:
 
 - **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3-0) open-source license ideal for students and enthusiasts keen on contributing to open projects. See the [LICENSE](LICENSE) file for details.
 - **Enterprise License**: Designed for commercial applications, this license permits the integration of Ultralytics software and AI models into commercial products and services without the open-source stipulations of AGPL-3.0. For commercial use inquiries, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
-## 📬 Contact Us
+## 📮 Contact
 
 For bug reports, feature suggestions, and contributions, please visit [GitHub Issues](https://github.com/ultralytics/petsys/issues). For broader questions and discussions related to this project or other Ultralytics initiatives, join our active community on [Discord](https://discord.com/invite/ultralytics)!
 


### PR DESCRIPTION
Second standardization pass: aligns the README tail with the canonical Ultralytics structure.

- Renamed the closing sections to the canonical headings: `## 💡 Contribute`, `## 📄 License`, `## 📮 Contact`.

Section prose, badges, banner, and all body content are unchanged. The `.github/` license headers and the LICENSE file were audited and already correct.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refines README section headings with clearer, more consistent emoji labels. ✨

### 📊 Key Changes

- Renamed **“🤝 Contribute”** to **“💡 Contribute”**.
- Renamed **“©️ License”** to **“📄 License”**.
- Renamed **“📬 Contact Us”** to **“📮 Contact”**.
- No functional code, dataset, or tooling changes were introduced.

### 🎯 Purpose & Impact

- Improves visual consistency and readability across the README. 📝
- Uses simpler, more descriptive headings to help readers find contribution, licensing, and contact information.
- Has no impact on project behavior, APIs, or users’ workflows. ✅